### PR TITLE
Add pypi publishing to CI (#8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
     - lint
-    - test
     if: startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/pull/')
 
     steps:
@@ -88,6 +87,10 @@ jobs:
       run: python3 -m pip install build --user
 
     - name: Build a binary wheel and a source tarball
+      # Use a fake version number for non-tagged runs.
+      # Tagged runs are for actual releases.
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ !startsWith(github.ref, 'refs/tags/') && format('0.1.dev{0}', github.run_number) || '' }}
       run: python3 -m build
 
     - name: Store the distribution packages
@@ -98,7 +101,9 @@ jobs:
 
   test-wheel:
     runs-on: ubuntu-22.04
-    needs: build-wheel
+    needs:
+    - build-wheel
+    - test  # DO NOT REMOVE; publish depends on test-wheel
 
     steps:
     - uses: actions/checkout@v4
@@ -136,6 +141,58 @@ jobs:
         cat agproject.yml
         cat loaded.agproject.yml
 
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build-wheel
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/autograder-cli
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:  # test-wheel depends on test
+    - test-wheel
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/autograder-cli  # Replace <package-name> with your PyPI project name
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
+
+
   # See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   github-release:
     name: >-
@@ -143,8 +200,7 @@ jobs:
       and upload them to GitHub Release
 
     needs:
-    - test-wheel
-    if: startsWith(github.ref, 'refs/tags/')
+    - publish-to-pypi
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
* Add pypi publishing to CI, take 2

* Restore build-wheel condition to run on PRs

* Add verbose: true to pypi publish action

* Update job CI dependencies so that we can see if test-pypi publishing works before tests finish running.

* Use fake (not local) version number whin building wheel on non-tagged runs.